### PR TITLE
Fixed isPowerOfTwo in BitmapTexture.java

### DIFF
--- a/library/src/main/java/org/traxnet/shadingzen/core/BitmapTexture.java
+++ b/library/src/main/java/org/traxnet/shadingzen/core/BitmapTexture.java
@@ -106,7 +106,7 @@ public class BitmapTexture extends Resource implements Texture {
 	}
 	
 	boolean isPowerOfTwo(int i){
-		return (2 * i == (i ^( i - 1) + 1));
+		return ( i & (i - 1)) == 0;
 	}
 	
 	public boolean isCubemap(){


### PR DESCRIPTION
Fix for function `isPowerOfTwo` in `core\BitmapTexture.java`

Testing example:

```
class Main {
    static boolean isPowerOfTwo(int i){
        return (2 * i == (i ^( i - 1) + 1));
    }

    //fixed version
    static boolean isPowerOfTwo2(int i){
        return ( i & (i - 1)) == 0;
    }

    public static void main(String[] args) {
      System.out.println(isPowerOfTwo(8));
      System.out.println(isPowerOfTwo2(8));
    }
}
```

Output:

```
false
true
```
